### PR TITLE
Add preliminary GraphQL server pesy template

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -12,7 +12,7 @@ You need Esy, you can install the beta using [npm](https://npmjs.com):
 
 > NOTE: Make sure `esy --version` returns at least `0.5.8` for this project to build.
 
-Then run the `esy` command from this project root to install and build depenencies.
+Then run the `esy` command from this project root to install and build dependencies.
 
     % esy
 
@@ -21,11 +21,12 @@ You can start the server to try it out (runs `scripts.start` specified in
 
     % esy start
 
-This will start a simple server that runs on port 8080 and has the following routes:
+This will start a simple graphql server that runs on port 8080 and has the following routes:
 
-    / -> responds with "Hello world!"
-    /greet/:name -> responds with "Hello ${name}!"
-    /static/path/to/file -> responds with the file
+    GET / -> responds with "Hello world!"
+    GET /greet/:name -> responds with "Hello ${name}!"
+    GET /graphql -> responds GraphiQL user interface
+    POST /graphql -> responds with GraphQL response
 
 After you make some changes to source code, you can re-run project's build
 again with the same simple `esy` command.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# moprh-hello-world-pesy-template
+# morph-graphql-server-pesy-template
 
 > Note: This is a template and since it contains template variables, it cannot be used on it's own.
 
@@ -18,5 +18,5 @@ Then create a project folder, cd into that folder and create the project from th
 ```sh
 mkdir my-project
 cd my-project
-pesy --template=reason-native-web/morph-hello-world-pesy-template
+pesy --template=reason-native-web/morph-graphql-server-pesy-template
 ```

--- a/bin/__PACKAGE_NAME_UPPER_CAMEL__App.re
+++ b/bin/__PACKAGE_NAME_UPPER_CAMEL__App.re
@@ -2,6 +2,8 @@ Fmt_tty.setup_std_outputs();
 Logs.set_level(Some(Logs.Info));
 Logs.set_reporter(Logs_fmt.reporter());
 
+let graphql_handler = Morph_graphql_server.make(Library.Schema.schema);
+
 let handler = (request: Morph.Request.t) => {
   open Morph;
 
@@ -16,8 +18,9 @@ let handler = (request: Morph.Request.t) => {
   | (_, []) => Morph.Response.text("Hello world!", Response.empty)
   | (_, ["greet", name]) =>
     Morph.Response.text("Hello " ++ name ++ "!", Response.empty)
-  | (`GET, ["static", ...file_path]) =>
-    Morph.Response.static(file_path |> String.concat("/"), Response.empty)
+  | (`GET, ["graphql"]) =>
+    Morph.Response.text(Library.GraphiQL.html, Morph.Response.empty)
+  | (_, ["graphql"]) => graphql_handler(request)
   | (_, _) => Response.not_found(Response.empty)
   };
 };

--- a/library/GraphiQL.re
+++ b/library/GraphiQL.re
@@ -1,0 +1,112 @@
+let html = {|
+<!--
+The request to this GraphQL server provided the header "Accept: text/html"
+and as a result has been presented GraphiQL - an in-browser IDE for
+exploring GraphQL.
+If you wish to receive JSON, provide the header "Accept: application/json" or
+add "&raw" to the end of the URL within a browser.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      width: 100%;
+    }
+  </style>
+  <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.js"></script>
+  <script src="//unpkg.com/subscriptions-transport-ws@0.8.1/browser/client.js"></script>
+  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+</head>
+<body>
+  <script>
+    // Collect the URL parameters
+    var parameters = {};
+    window.location.search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+    // Produce a Location query string from a parameter object.
+    function locationQuery(params) {
+      return '?' + Object.keys(params).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(params[key]);
+      }).join('&');
+    }
+    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
+    var graphqlParamNames = {
+      query: true,
+      variables: true,
+      operationName: true
+    };
+    var otherParams = {};
+    for (var k in parameters) {
+      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
+        otherParams[k] = parameters[k];
+      }
+    }
+    // Defines a GraphQL fetcher using the fetch API.
+    function graphQLFetcher(graphQLParams) {
+      return fetch(window.location, {
+        method: 'post',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(graphQLParams),
+      }).then(function (response) {
+        return response.text();
+      }).then(function (responseBody) {
+        try {
+          return JSON.parse(responseBody);
+        } catch (error) {
+          return responseBody;
+        }
+      });
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared.
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+    function updateURL() {
+      history.replaceState(null, null, locationQuery(parameters));
+    }
+    var subscriptionsClient = new SubscriptionsTransportWs.SubscriptionClient('ws://' + window.location.host + window.location.pathname, { reconnect: true });
+    var subscriptionsFetcher = GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+    // Render <GraphiQL /> into the body.
+    ReactDOM.render(
+      React.createElement(GraphiQL, {
+        fetcher: subscriptionsFetcher,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        onEditOperationName: onEditOperationName,
+        query: parameters.query,
+        response: parameters.response,
+        variables: parameters.variables,
+        operationName: parameters.operationName,
+      }),
+      document.body
+    );
+  </script>
+</body>
+</html>
+|};

--- a/library/Schema.re
+++ b/library/Schema.re
@@ -1,0 +1,70 @@
+open Graphql_lwt;
+
+type user = {
+  id: int,
+  name: string,
+  email: string,
+};
+
+let users =
+  ref([
+    {id: 1, name: "Ulrik Strid", email: "ulrik@strid.com"},
+    {id: 2, name: "Cem Turan", email: "cem2ran@gmail.com"},
+  ]);
+
+let user =
+  Schema.(
+    obj("user", ~doc="A user in the system", ~fields=_ =>
+      [
+        field("id", ~typ=non_null(int), ~args=Arg.[], ~resolve=(info, p) =>
+          p.id
+        ),
+        field(
+          "name", ~typ=non_null(string), ~args=Arg.[], ~resolve=(info, p) =>
+          p.name
+        ),
+        field(
+          "email", ~typ=non_null(string), ~args=Arg.[], ~resolve=(info, p) =>
+          p.email
+        ),
+      ]
+    )
+  );
+
+let schema: Schema.schema(Hmap.t) =
+  Schema.(
+    schema(
+      ~mutations=[
+        field(
+          "addUser",
+          ~typ=non_null(user),
+          ~args=
+            Arg.[
+              arg("name", non_null(string)),
+              arg("email", non_null(string)),
+            ],
+          ~resolve=(_info, (), name, email) => {
+            let new_user = {id: List.length(users^) + 1, name, email};
+            users := [new_user, ...users^];
+            new_user;
+          },
+        ),
+      ],
+      [
+        field(
+          "users",
+          ~typ=non_null(list(non_null(user))),
+          ~args=Arg.[],
+          ~resolve=(_info, ()) =>
+          users^
+        ),
+        field(
+          "userById",
+          ~typ=user,
+          ~args=Arg.[arg("id", non_null(int))],
+          ~resolve=(_info, (), id) =>
+          List.find_opt(u => u.id == id, users^)
+        ),
+      ],
+    )
+  );

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
       "imports": [
         "Opium_core = require('opium_core')",
         "Morph = require('morph')",
+        "Morph_graphql_server = require('morph_graphql_server')",
+        "Graphql_lwt = require('graphql-lwt')",
         "Mtime = require('mtime')",
         "Mtime_clock = require('mtime/clock/os')",
         "Logs = require('logs')",
@@ -71,6 +73,7 @@
     "@reason-native-web/morph": "*",
     "@reason-native-web/morph_server": "*",
     "@reason-native-web/morph_server_http": "*",
+    "@reason-native-web/morph_graphql_server": "*",
     "@opam/mtime": "*",
     "@opam/uri": "*"
   },


### PR DESCRIPTION
Works fine, tested by running pesy with a reference to repo + commit hash:
```
pesy --template=cem2ran/morph-graphql-server-pesy-template#ae31f61f73526e2cf2a07400cad5962da1a4bf35
```

Haven't yet handled the websocket case in the router:
https://github.com/andreas/ocaml-graphql-server/blob/8c14d9e0b0c5ef2eda6c19df0c9d56fd811f13fd/graphql-cohttp/src/graphql_cohttp.ml#L105-L108